### PR TITLE
增加块标移动过渡效果、横版斜杠菜单、增亮文字颜色

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -53,7 +53,7 @@
     /* 文字颜色 */
     --b3-theme-on-primary: #fff;
     --b3-theme-on-secondary: #fff;
-    --b3-theme-on-background: #c9d1d9;
+    --b3-theme-on-background: #ededed;
     --b3-theme-on-surface: #9aa0a6;
     --b3-theme-on-error: #fff;
 
@@ -1605,6 +1605,8 @@ div[data-subtype='t'][data-type='NodeList'] {
 /* 块标提示不被窗口线遮挡 */
 .protyle-gutters {
     z-index: 3;
+    /* 块标移动增加过渡 */
+    transition: all 200ms ease-out;
 }
 /* pdf双链 */
 .protyle-wysiwyg [data-node-id] span[data-type='file-annotation-ref'] {
@@ -1827,6 +1829,15 @@ div[style*="background-color: var(--b3-font-background"] [contenteditable="true"
     border-radius: 6px;
     padding: 6px 6px 6px;
     min-width: 200px;
+}
+/* 横版斜杠菜单 */
+.b3-menu,.b3-menu .b3-menu__submenu {
+    column-count: 4;
+    column-width: 160px !important;
+    column-gap: 10px;
+    column-rule: 1px solid #13c2c240;
+    min-width: 50vw !important;
+    max-height: 480px !important;
 }
 .b3-menu .b3-menu__submenu {
     margin-left: 10px;

--- a/theme.css
+++ b/theme.css
@@ -1831,9 +1831,7 @@ div[style*="background-color: var(--b3-font-background"] [contenteditable="true"
     min-width: 200px;
 }
 /* 横版斜杠菜单 */
-/* .b3-menu,.b3-menu .b3-menu__submenu { */
 .b3-menu.b3-list.b3-list--background.hint--menu{
-
     column-count: 4;
     column-width: 160px !important;
     column-gap: 10px;

--- a/theme.css
+++ b/theme.css
@@ -1831,7 +1831,9 @@ div[style*="background-color: var(--b3-font-background"] [contenteditable="true"
     min-width: 200px;
 }
 /* 横版斜杠菜单 */
-.b3-menu,.b3-menu .b3-menu__submenu {
+/* .b3-menu,.b3-menu .b3-menu__submenu { */
+.b3-menu.b3-list.b3-list--background.hint--menu{
+
     column-count: 4;
     column-width: 160px !important;
     column-gap: 10px;


### PR DESCRIPTION
1. 块标移动过渡效果，从 notion theme 那学的，效果如下（录屏录的是notion theme），看着极其舒适

https://user-images.githubusercontent.com/68107073/171659804-f90325f2-652c-4701-aaab-1f90f260bb83.mp4

2. 横版斜杠菜单
![image](https://user-images.githubusercontent.com/68107073/171660423-23c9847d-1301-4f84-8d96-ce2641aecff3.png)

3. 增亮文字颜色
原来的文字颜色感觉有点暗，增亮了一些